### PR TITLE
Add survey attachment list/export and deletion scripts

### DIFF
--- a/Deletion/delete-survey-attachments/delete-survey-attachments.ps1
+++ b/Deletion/delete-survey-attachments/delete-survey-attachments.ps1
@@ -15,7 +15,8 @@ param(
     [string]$ConnectionString,
     [Parameter(Mandatory=$true)]
     [int]$SurveyID,
-    [switch]$DryRun
+    [switch]$DryRun,
+    [switch]$IncludeSoftDeleted
 )
 
 # Normalize connection string keywords that Invoke-Sqlcmd may not accept
@@ -41,6 +42,7 @@ SELECT
         WHEN 0 THEN 'Database'
         WHEN 1 THEN 'Amazon S3'
     END AS StorageLocation,
+    fu.Deleted AS SoftDeleted,
     r.ResponseID,
     CASE
         WHEN fuf.FileID IS NOT NULL THEN 'File Upload'
@@ -52,7 +54,7 @@ LEFT JOIN ckbx_ItemData_Signature_Files sf ON fu.FileID = sf.FileID
 INNER JOIN ckbx_ResponseAnswers ra ON COALESCE(fuf.AnswerID, sf.AnswerID) = ra.AnswerID
 INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
 WHERE r.ResponseTemplateID = $SurveyID
-  AND fu.Deleted = 0;
+  AND (fu.Deleted = 0$(if ($IncludeSoftDeleted) { " OR fu.Deleted = 1" }));
 "@
 
 $attachments = @(Invoke-Sqlcmd -ConnectionString $connString -Query $previewQuery)
@@ -65,7 +67,9 @@ if ($attachments.Count -eq 0) {
 # Show what will be deleted
 $mode = if ($DryRun) { "DRY RUN" } else { "DELETE" }
 Write-Host "`n[$mode] Found $($attachments.Count) attachment(s) for SurveyID ${SurveyID}:`n" -ForegroundColor $(if ($DryRun) { "Cyan" } else { "Red" })
-$attachments | Format-Table FileID, FileName, FileSize, StorageLocation, ResponseID, AttachmentType -AutoSize
+$tableColumns = @("FileID", "FileName", "FileSize", "StorageLocation", "ResponseID", "AttachmentType")
+if ($IncludeSoftDeleted) { $tableColumns += "SoftDeleted" }
+$attachments | Format-Table $tableColumns -AutoSize
 
 $totalSize = ($attachments | Measure-Object -Property FileSize -Sum).Sum
 Write-Host "Total size: $([math]::Round($totalSize / 1MB, 2)) MB ($totalSize bytes)" -ForegroundColor Cyan
@@ -106,7 +110,7 @@ BEGIN TRY
     INNER JOIN ckbx_ResponseAnswers ra ON fuf.AnswerID = ra.AnswerID
     INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
     WHERE r.ResponseTemplateID = $SurveyID
-      AND fu.Deleted = 0;
+      AND (fu.Deleted = 0$(if ($IncludeSoftDeleted) { " OR fu.Deleted = 1" }));
 
     -- Collect FileIDs to delete (signatures)
     SELECT sf.FileID, sf.AnswerID
@@ -116,7 +120,7 @@ BEGIN TRY
     INNER JOIN ckbx_ResponseAnswers ra ON sf.AnswerID = ra.AnswerID
     INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
     WHERE r.ResponseTemplateID = $SurveyID
-      AND fu.Deleted = 0;
+      AND (fu.Deleted = 0$(if ($IncludeSoftDeleted) { " OR fu.Deleted = 1" }));
 
     -- Remove linking rows
     DELETE fuf

--- a/Deletion/delete-survey-attachments/delete-survey-attachments.ps1
+++ b/Deletion/delete-survey-attachments/delete-survey-attachments.ps1
@@ -1,0 +1,159 @@
+# ============================================================
+# Delete attachments for a specific survey
+#
+# Usage (dry run — shows what would be deleted, no changes made):
+#   .\delete-survey-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012 -DryRun
+#
+# Usage (actual delete):
+#   .\delete-survey-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012
+#
+# The ConnectionString is the same value as DefaultConnection in your Checkbox appsettings.json.
+# ============================================================
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ConnectionString,
+    [Parameter(Mandatory=$true)]
+    [int]$SurveyID,
+    [switch]$DryRun
+)
+
+# Normalize connection string keywords that Invoke-Sqlcmd may not accept
+$connString = $ConnectionString
+$connString = $connString -replace "(?i)Trust Server Certificate", "TrustServerCertificate"
+$connString = $connString -replace "(?i)Initial Catalog", "Database"
+$connString = $connString -replace "(?i)Data Source", "Server"
+$connString = $connString -replace "(?i)User ID", "User Id"
+$connString = $connString -replace "(?i)Connect Timeout", "Connection Timeout"
+if ($connString -notmatch "(?i)TrustServerCertificate") {
+    $connString += ";TrustServerCertificate=true"
+}
+
+# Query attachments that would be affected
+$previewQuery = @"
+SELECT
+    fu.FileID,
+    fu.FileName,
+    fu.FileType,
+    fu.FileSize,
+    fu.StorageType,
+    CASE fu.StorageType
+        WHEN 0 THEN 'Database'
+        WHEN 1 THEN 'Amazon S3'
+    END AS StorageLocation,
+    r.ResponseID,
+    CASE
+        WHEN fuf.FileID IS NOT NULL THEN 'File Upload'
+        WHEN sf.FileID IS NOT NULL THEN 'Signature'
+    END AS AttachmentType
+FROM ckbx_FileUpload fu
+LEFT JOIN ckbx_ItemData_FileUpload_Files fuf ON fu.FileID = fuf.FileID
+LEFT JOIN ckbx_ItemData_Signature_Files sf ON fu.FileID = sf.FileID
+INNER JOIN ckbx_ResponseAnswers ra ON COALESCE(fuf.AnswerID, sf.AnswerID) = ra.AnswerID
+INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
+WHERE r.ResponseTemplateID = $SurveyID
+  AND fu.Deleted = 0;
+"@
+
+$attachments = @(Invoke-Sqlcmd -ConnectionString $connString -Query $previewQuery)
+
+if ($attachments.Count -eq 0) {
+    Write-Host "No attachments found for SurveyID $SurveyID." -ForegroundColor Yellow
+    exit
+}
+
+# Show what will be deleted
+$mode = if ($DryRun) { "DRY RUN" } else { "DELETE" }
+Write-Host "`n[$mode] Found $($attachments.Count) attachment(s) for SurveyID ${SurveyID}:`n" -ForegroundColor $(if ($DryRun) { "Cyan" } else { "Red" })
+$attachments | Format-Table FileID, FileName, FileSize, StorageLocation, ResponseID, AttachmentType -AutoSize
+
+$totalSize = ($attachments | Measure-Object -Property FileSize -Sum).Sum
+Write-Host "Total size: $([math]::Round($totalSize / 1MB, 2)) MB ($totalSize bytes)" -ForegroundColor Cyan
+
+# Warn about S3-stored files
+$s3Files = @($attachments | Where-Object { $_.StorageType -eq 1 })
+if ($s3Files.Count -gt 0) {
+    Write-Host "`nWARNING: $($s3Files.Count) file(s) are stored in Amazon S3." -ForegroundColor Yellow
+    Write-Host "This script will remove the database records but the actual S3 objects will remain" -ForegroundColor Yellow
+    Write-Host "and must be deleted separately from the S3 bucket." -ForegroundColor Yellow
+    $s3Files | Format-Table FileID, FileName, FileSize -AutoSize
+}
+
+if ($DryRun) {
+    Write-Host "`nDry run complete. No changes were made." -ForegroundColor Cyan
+    Write-Host "To delete, run again without -DryRun." -ForegroundColor Cyan
+    exit
+}
+
+# Confirm before proceeding
+Write-Host ""
+$confirm = Read-Host "Are you sure you want to permanently delete these $($attachments.Count) attachment(s)? (yes/no)"
+if ($confirm -ne "yes") {
+    Write-Host "Aborted." -ForegroundColor Yellow
+    exit
+}
+
+# Execute deletion
+$deleteQuery = @"
+BEGIN TRANSACTION;
+
+BEGIN TRY
+    -- Collect FileIDs to delete (file uploads)
+    SELECT fuf.FileID, fuf.AnswerID
+    INTO #FileUploadFilesToDelete
+    FROM ckbx_ItemData_FileUpload_Files fuf
+    INNER JOIN ckbx_ResponseAnswers ra ON fuf.AnswerID = ra.AnswerID
+    INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
+    WHERE r.ResponseTemplateID = $SurveyID;
+
+    -- Collect FileIDs to delete (signatures)
+    SELECT sf.FileID, sf.AnswerID
+    INTO #SignatureFilesToDelete
+    FROM ckbx_ItemData_Signature_Files sf
+    INNER JOIN ckbx_ResponseAnswers ra ON sf.AnswerID = ra.AnswerID
+    INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
+    WHERE r.ResponseTemplateID = $SurveyID;
+
+    -- Remove linking rows
+    DELETE fuf
+    FROM ckbx_ItemData_FileUpload_Files fuf
+    INNER JOIN #FileUploadFilesToDelete d ON fuf.FileID = d.FileID AND fuf.AnswerID = d.AnswerID;
+
+    DELETE sf
+    FROM ckbx_ItemData_Signature_Files sf
+    INNER JOIN #SignatureFilesToDelete d ON sf.FileID = d.FileID AND sf.AnswerID = d.AnswerID;
+
+    -- Delete file records (and their binary data)
+    DELETE fu
+    FROM ckbx_FileUpload fu
+    WHERE fu.FileID IN (
+        SELECT FileID FROM #FileUploadFilesToDelete
+        UNION
+        SELECT FileID FROM #SignatureFilesToDelete
+    );
+
+    SELECT @@ROWCOUNT AS DeletedFiles;
+
+    DROP TABLE #FileUploadFilesToDelete;
+    DROP TABLE #SignatureFilesToDelete;
+
+    COMMIT TRANSACTION;
+END TRY
+BEGIN CATCH
+    ROLLBACK TRANSACTION;
+
+    IF OBJECT_ID('tempdb..#FileUploadFilesToDelete') IS NOT NULL DROP TABLE #FileUploadFilesToDelete;
+    IF OBJECT_ID('tempdb..#SignatureFilesToDelete') IS NOT NULL DROP TABLE #SignatureFilesToDelete;
+
+    THROW;
+END CATCH;
+"@
+
+try {
+    $result = Invoke-Sqlcmd -ConnectionString $connString -Query $deleteQuery
+    Write-Host "`nDeleted $($result.DeletedFiles) file(s) for SurveyID $SurveyID." -ForegroundColor Green
+}
+catch {
+    Write-Host "`nError: $_" -ForegroundColor Red
+    Write-Host "Transaction was rolled back. No data was deleted." -ForegroundColor Yellow
+}

--- a/Deletion/delete-survey-attachments/delete-survey-attachments.ps1
+++ b/Deletion/delete-survey-attachments/delete-survey-attachments.ps1
@@ -7,7 +7,7 @@
 # Usage (actual delete):
 #   .\delete-survey-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012
 #
-# The ConnectionString is the same value as DefaultConnection in your Checkbox appsettings.json.
+# The ConnectionString is the same value as connectionStrings.default in your Checkbox appsettings.json.
 # ============================================================
 
 param(
@@ -102,17 +102,21 @@ BEGIN TRY
     SELECT fuf.FileID, fuf.AnswerID
     INTO #FileUploadFilesToDelete
     FROM ckbx_ItemData_FileUpload_Files fuf
+    INNER JOIN ckbx_FileUpload fu ON fu.FileID = fuf.FileID
     INNER JOIN ckbx_ResponseAnswers ra ON fuf.AnswerID = ra.AnswerID
     INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
-    WHERE r.ResponseTemplateID = $SurveyID;
+    WHERE r.ResponseTemplateID = $SurveyID
+      AND fu.Deleted = 0;
 
     -- Collect FileIDs to delete (signatures)
     SELECT sf.FileID, sf.AnswerID
     INTO #SignatureFilesToDelete
     FROM ckbx_ItemData_Signature_Files sf
+    INNER JOIN ckbx_FileUpload fu ON fu.FileID = sf.FileID
     INNER JOIN ckbx_ResponseAnswers ra ON sf.AnswerID = ra.AnswerID
     INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
-    WHERE r.ResponseTemplateID = $SurveyID;
+    WHERE r.ResponseTemplateID = $SurveyID
+      AND fu.Deleted = 0;
 
     -- Remove linking rows
     DELETE fuf

--- a/Deletion/delete-survey-attachments/delete-survey-attachments.ps1
+++ b/Deletion/delete-survey-attachments/delete-survey-attachments.ps1
@@ -1,13 +1,16 @@
 # ============================================================
 # Delete attachments for a specific survey
 #
-# Usage (dry run — shows what would be deleted, no changes made):
+# Parameters:
+#   -ConnectionString (required)  connectionStrings.default from your Checkbox appsettings.json
+#   -SurveyID         (required)  the survey's ResponseTemplateID
+#   -DryRun                       preview what would be deleted without making changes
+#   -IncludeSoftDeleted           also target attachments marked as soft-deleted
+#
+# Usage:
 #   .\delete-survey-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012 -DryRun
-#
-# Usage (actual delete):
-#   .\delete-survey-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012
-#
-# The ConnectionString is the same value as connectionStrings.default in your Checkbox appsettings.json.
+#   .\delete-survey-attachments.ps1 -ConnectionString "..." -SurveyID 1012
+#   .\delete-survey-attachments.ps1 -ConnectionString "..." -SurveyID 1012 -IncludeSoftDeleted -DryRun
 # ============================================================
 
 param(

--- a/Deletion/delete-survey-attachments/readme.md
+++ b/Deletion/delete-survey-attachments/readme.md
@@ -13,7 +13,7 @@ This script can only be used for on-premises installations.
 
 Parameters:
 
-- `[string]$ConnectionString` (required) — the `connectionStrings.default` value from your Checkbox `appsettings.json`
+- `[string]$ConnectionString` (required) — your Checkbox database connection string (see [Finding your connection string](#finding-your-connection-string))
 - `[int]$SurveyID` (required) — the survey's ResponseTemplateID
 - `[switch]$DryRun` — preview what would be deleted without making any changes
 - `[switch]$IncludeSoftDeleted` — also target attachments that have been soft-deleted
@@ -40,6 +40,11 @@ The script removes, within a single transaction:
 2. File records (and binary data) in `ckbx_FileUpload`
 
 Only attachments belonging to responses for the specified survey are affected. If anything goes wrong, the entire transaction is rolled back and no data is deleted.
+
+## Finding your connection string
+
+- **Checkbox 8**: `connectionStrings.default` in `appsettings.json` (in the API Core application directory)
+- **Checkbox 7**: `DefaultConnection` in `Web.config` (in the API application directory, under `<connectionStrings>`)
 
 ## Notes
 

--- a/Deletion/delete-survey-attachments/readme.md
+++ b/Deletion/delete-survey-attachments/readme.md
@@ -16,6 +16,7 @@ Parameters:
 - `[string]$ConnectionString` (required) — the `connectionStrings.default` value from your Checkbox `appsettings.json`
 - `[int]$SurveyID` (required) — the survey's ResponseTemplateID
 - `[switch]$DryRun` — preview what would be deleted without making any changes
+- `[switch]$IncludeSoftDeleted` — also target attachments that have been soft-deleted
 
 ### Dry run (preview only, no changes)
 

--- a/Deletion/delete-survey-attachments/readme.md
+++ b/Deletion/delete-survey-attachments/readme.md
@@ -1,0 +1,49 @@
+# delete-survey-attachments
+
+This script permanently deletes all file attachments (file uploads and signatures) for a specific survey from the Checkbox database. It includes a dry-run mode to preview what would be deleted before making any changes.
+
+This script can only be used for on-premises installations.
+
+## Requirements
+
+- PowerShell 5.1+
+- `SqlServer` PowerShell module (`Install-Module SqlServer` if not already installed)
+
+## Usage
+
+Parameters:
+
+- `[string]$ConnectionString` (required) — the `DefaultConnection` value from your Checkbox `appsettings.json`
+- `[int]$SurveyID` (required) — the survey's ResponseTemplateID
+- `[switch]$DryRun` — preview what would be deleted without making any changes
+
+### Dry run (preview only, no changes)
+
+```ps1
+.\delete-survey-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012 -DryRun
+```
+
+### Delete attachments
+
+```ps1
+.\delete-survey-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012
+```
+
+You will be asked to confirm before any data is deleted.
+
+## What gets deleted
+
+The script removes, within a single transaction:
+
+1. Linking rows in `ckbx_ItemData_FileUpload_Files` and `ckbx_ItemData_Signature_Files`
+2. File records (and binary data) in `ckbx_FileUpload`
+
+Only attachments belonging to responses for the specified survey are affected. If anything goes wrong, the entire transaction is rolled back and no data is deleted.
+
+## Notes
+
+- **Always run with `-DryRun` first** to review what will be affected.
+- **Back up your database** before running without `-DryRun`.
+- Use the companion script `list-and-export-attachments` (in `Surveys/list-and-export-attachments`) to export attachment files to disk before deleting.
+- If any files are stored in Amazon S3 (`StorageType=1`), the script will warn you — it removes the database records but the actual S3 objects must be deleted separately.
+- The `ConnectionString` is automatically normalized to handle common keyword variants (e.g., `Initial Catalog` vs `Database`, `Trust Server Certificate` vs `TrustServerCertificate`).

--- a/Deletion/delete-survey-attachments/readme.md
+++ b/Deletion/delete-survey-attachments/readme.md
@@ -13,7 +13,7 @@ This script can only be used for on-premises installations.
 
 Parameters:
 
-- `[string]$ConnectionString` (required) — the `DefaultConnection` value from your Checkbox `appsettings.json`
+- `[string]$ConnectionString` (required) — the `connectionStrings.default` value from your Checkbox `appsettings.json`
 - `[int]$SurveyID` (required) — the survey's ResponseTemplateID
 - `[switch]$DryRun` — preview what would be deleted without making any changes
 

--- a/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
+++ b/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
@@ -94,6 +94,16 @@ $attachments | Format-Table $tableColumns -AutoSize
 # Resolve to absolute path using PowerShell's $PWD (not .NET's working directory)
 $OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputPath)
 
+# Check if output directory already has content
+if ((Test-Path $OutputPath) -and (Get-ChildItem $OutputPath | Measure-Object).Count -gt 0) {
+    Write-Host "Output directory already contains files: $OutputPath" -ForegroundColor Yellow
+    $confirm = Read-Host "Existing files may be overwritten. Continue? (yes/no)"
+    if ($confirm -ne "yes") {
+        Write-Host "Aborted." -ForegroundColor Yellow
+        exit
+    }
+}
+
 # Create output directory and export CSV report
 New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
 $csvPath = Join-Path $OutputPath "attachments-report.csv"

--- a/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
+++ b/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
@@ -150,7 +150,13 @@ foreach ($att in $attachments) {
             $bytes = [byte[]]::new($size)
             $reader.GetBytes(0, 0, $bytes, 0, $size)
 
-            $filePath = Join-Path $folder $att.FileName
+            $name = [System.IO.Path]::GetFileNameWithoutExtension($att.FileName)
+            $ext = [System.IO.Path]::GetExtension($att.FileName)
+            $targetName = $att.FileName
+            if (Test-Path (Join-Path $folder $targetName)) {
+                $targetName = "${name}_FileID$($att.FileID)${ext}"
+            }
+            $filePath = Join-Path $folder $targetName
             [System.IO.File]::WriteAllBytes($filePath, $bytes)
             Write-Host "  OK   FileID $($att.FileID) -> $filePath" -ForegroundColor Green
             $exported++

--- a/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
+++ b/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
@@ -14,7 +14,8 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$ConnectionString,
     [string]$OutputPath = ".\CheckboxAttachments",
-    [int]$SurveyID = 0
+    [int]$SurveyID = 0,
+    [switch]$IncludeSoftDeleted
 )
 
 # Build query — when filtering by survey, use INNER JOINs up the response chain
@@ -42,6 +43,7 @@ SELECT
         WHEN 1 THEN 'Amazon S3'
     END AS StorageLocation,
     DATALENGTH(fu.FileData) AS BinaryDataBytes,
+    fu.Deleted AS SoftDeleted,
     rt.ResponseTemplateID AS SurveyID,
     rt.TemplateName AS SurveyName,
     r.ResponseID,
@@ -60,7 +62,7 @@ $responseJoin ckbx_ResponseAnswers ra ON COALESCE(fuf.AnswerID, sf.AnswerID) = r
 $responseJoin ckbx_Response r ON ra.ResponseID = r.ResponseID
 LEFT JOIN ckbx_ResponseTemplate rt ON r.ResponseTemplateID = rt.ResponseTemplateID
 LEFT JOIN ckbx_Item i ON ra.ItemID = i.ItemID
-WHERE fu.Deleted = 0 $surveyFilter
+WHERE (fu.Deleted = 0$(if ($IncludeSoftDeleted) { " OR fu.Deleted = 1" })) $surveyFilter
 ORDER BY rt.TemplateName, r.ResponseID, fu.CreatedDate DESC;
 "@
 
@@ -85,7 +87,9 @@ if ($attachments.Count -eq 0) {
 
 # Print summary to console
 Write-Host "`nFound $($attachments.Count) attachment(s):`n" -ForegroundColor Green
-$attachments | Format-Table FileID, FileName, FileSize, StorageLocation, SurveyName, ResponseID, AttachmentType -AutoSize
+$tableColumns = @("FileID", "FileName", "FileSize", "StorageLocation", "SurveyName", "ResponseID", "AttachmentType")
+if ($IncludeSoftDeleted) { $tableColumns += "SoftDeleted" }
+$attachments | Format-Table $tableColumns -AutoSize
 
 # Resolve to absolute path using PowerShell's $PWD (not .NET's working directory)
 $OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputPath)
@@ -94,7 +98,7 @@ $OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromP
 New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
 $csvPath = Join-Path $OutputPath "attachments-report.csv"
 $attachments | Select-Object FileID, FileGuid, FileName, FileType, FileSize, MIMEContentType,
-    CreatedDate, StorageType, StorageLocation, BinaryDataBytes, SurveyID, SurveyName,
+    CreatedDate, StorageType, StorageLocation, BinaryDataBytes, SoftDeleted, SurveyID, SurveyName,
     ResponseID, ResponseGUID, AnswerID, QuestionAlias, AttachmentType |
     Export-Csv -Path $csvPath -NoTypeInformation
 Write-Host "CSV report saved to: $csvPath" -ForegroundColor Cyan

--- a/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
+++ b/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
@@ -131,8 +131,8 @@ foreach ($att in $attachments) {
     }
 
     # Build folder path: files/<SurveyName>/Response-<ResponseID>/
-    $surveyFolder = if ($att.SurveyName) { $att.SurveyName -replace '[\\/:*?"<>|]', '_' } else { "_Orphaned" }
-    $responseFolder = if ($att.ResponseID) { "Response-$($att.ResponseID)" } else { "_NoResponse" }
+    $surveyFolder = if ($att.SurveyName -and $att.SurveyName -isnot [DBNull]) { $att.SurveyName -replace '[\\/:*?"<>|]', '_' } else { "_Orphaned" }
+    $responseFolder = if ($att.ResponseID -and $att.ResponseID -isnot [DBNull]) { "Response-$($att.ResponseID)" } else { "_NoResponse" }
     $folder = Join-Path $filesDir (Join-Path $surveyFolder $responseFolder)
     New-Item -ItemType Directory -Path $folder -Force | Out-Null
 

--- a/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
+++ b/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
@@ -1,0 +1,149 @@
+# ============================================================
+# List and export all survey attachments
+#
+# Usage (all attachments):
+#   .\list-and-export-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword"
+#
+# Usage (single survey):
+#   .\list-and-export-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012
+#
+# The ConnectionString is the same value as DefaultConnection in your Checkbox appsettings.json.
+# ============================================================
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ConnectionString,
+    [string]$OutputPath = ".\CheckboxAttachments",
+    [int]$SurveyID = 0
+)
+
+# Build query — when filtering by survey, use INNER JOINs up the response chain
+if ($SurveyID -gt 0) {
+    $surveyFilter = "AND r.ResponseTemplateID = $SurveyID"
+    $responseJoin = "INNER JOIN"
+    Write-Host "Filtering to SurveyID: $SurveyID" -ForegroundColor Cyan
+} else {
+    $surveyFilter = ""
+    $responseJoin = "LEFT JOIN"
+}
+
+$query = @"
+SELECT
+    fu.FileID,
+    fu.FileGuid,
+    fu.FileName,
+    fu.FileType,
+    fu.FileSize,
+    fu.MIMEContentType,
+    fu.CreatedDate,
+    fu.StorageType,
+    CASE fu.StorageType
+        WHEN 0 THEN 'Database'
+        WHEN 1 THEN 'Amazon S3'
+    END AS StorageLocation,
+    DATALENGTH(fu.FileData) AS BinaryDataBytes,
+    rt.ResponseTemplateID AS SurveyID,
+    rt.TemplateName AS SurveyName,
+    r.ResponseID,
+    r.GUID AS ResponseGUID,
+    ra.AnswerID,
+    i.Alias AS QuestionAlias,
+    CASE
+        WHEN fuf.FileID IS NOT NULL THEN 'File Upload'
+        WHEN sf.FileID IS NOT NULL THEN 'Signature'
+        ELSE 'Orphaned'
+    END AS AttachmentType
+FROM ckbx_FileUpload fu
+LEFT JOIN ckbx_ItemData_FileUpload_Files fuf ON fu.FileID = fuf.FileID
+LEFT JOIN ckbx_ItemData_Signature_Files sf ON fu.FileID = sf.FileID
+$responseJoin ckbx_ResponseAnswers ra ON COALESCE(fuf.AnswerID, sf.AnswerID) = ra.AnswerID
+$responseJoin ckbx_Response r ON ra.ResponseID = r.ResponseID
+LEFT JOIN ckbx_ResponseTemplate rt ON r.ResponseTemplateID = rt.ResponseTemplateID
+LEFT JOIN ckbx_Item i ON ra.ItemID = i.ItemID
+WHERE fu.Deleted = 0 $surveyFilter
+ORDER BY rt.TemplateName, r.ResponseID, fu.CreatedDate DESC;
+"@
+
+# Normalize connection string keywords that Invoke-Sqlcmd may not accept
+$connString = $ConnectionString
+$connString = $connString -replace "(?i)Trust Server Certificate", "TrustServerCertificate"
+$connString = $connString -replace "(?i)Initial Catalog", "Database"
+$connString = $connString -replace "(?i)Data Source", "Server"
+$connString = $connString -replace "(?i)User ID", "User Id"
+$connString = $connString -replace "(?i)Connect Timeout", "Connection Timeout"
+if ($connString -notmatch "(?i)TrustServerCertificate") {
+    $connString += ";TrustServerCertificate=true"
+}
+
+# Query the attachment listing
+$attachments = @(Invoke-Sqlcmd -ConnectionString $connString -Query $query)
+
+if ($attachments.Count -eq 0) {
+    Write-Host "No attachments found." -ForegroundColor Yellow
+    exit
+}
+
+# Print summary to console
+Write-Host "`nFound $($attachments.Count) attachment(s):`n" -ForegroundColor Green
+$attachments | Format-Table FileID, FileName, FileSize, StorageLocation, SurveyName, ResponseID, AttachmentType -AutoSize
+
+# Resolve to absolute path using PowerShell's $PWD (not .NET's working directory)
+$OutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputPath)
+
+# Create output directory and export CSV report
+New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+$csvPath = Join-Path $OutputPath "attachments-report.csv"
+$attachments | Select-Object FileID, FileGuid, FileName, FileType, FileSize, MIMEContentType,
+    CreatedDate, StorageType, StorageLocation, BinaryDataBytes, SurveyID, SurveyName,
+    ResponseID, ResponseGUID, AnswerID, QuestionAlias, AttachmentType |
+    Export-Csv -Path $csvPath -NoTypeInformation
+Write-Host "CSV report saved to: $csvPath" -ForegroundColor Cyan
+
+# Export DB-stored files to disk
+$filesDir = Join-Path $OutputPath "files"
+$exported = 0
+$skipped = 0
+
+# Query file binary data one at a time to avoid loading everything into memory
+foreach ($att in $attachments) {
+    if ($att.StorageType -ne 0) {
+        Write-Host "  SKIP FileID $($att.FileID) '$($att.FileName)' - S3-stored, cannot export from DB" -ForegroundColor Yellow
+        $skipped++
+        continue
+    }
+
+    # Build folder path: files/<SurveyName>/Response-<ResponseID>/
+    $surveyFolder = if ($att.SurveyName) { $att.SurveyName -replace '[\\/:*?"<>|]', '_' } else { "_Orphaned" }
+    $responseFolder = if ($att.ResponseID) { "Response-$($att.ResponseID)" } else { "_NoResponse" }
+    $folder = Join-Path $filesDir (Join-Path $surveyFolder $responseFolder)
+    New-Item -ItemType Directory -Path $folder -Force | Out-Null
+
+    # Fetch binary data for this file
+    $fileQuery = "SELECT FileData FROM ckbx_FileUpload WHERE FileID = $($att.FileID) AND FileData IS NOT NULL"
+    $conn = New-Object System.Data.SqlClient.SqlConnection($connString)
+    $conn.Open()
+    $cmd = $conn.CreateCommand()
+    $cmd.CommandText = $fileQuery
+    $reader = $cmd.ExecuteReader([System.Data.CommandBehavior]::SequentialAccess)
+
+    if ($reader.Read() -and -not $reader.IsDBNull(0)) {
+        $size = $reader.GetBytes(0, 0, $null, 0, 0)
+        $bytes = [byte[]]::new($size)
+        $reader.GetBytes(0, 0, $bytes, 0, $size)
+
+        $filePath = Join-Path $folder $att.FileName
+        [System.IO.File]::WriteAllBytes($filePath, $bytes)
+        Write-Host "  OK   FileID $($att.FileID) -> $filePath" -ForegroundColor Green
+        $exported++
+    }
+    else {
+        Write-Host "  SKIP FileID $($att.FileID) '$($att.FileName)' - no binary data in FileData column" -ForegroundColor Yellow
+        $skipped++
+    }
+
+    $reader.Close()
+    $conn.Close()
+}
+
+Write-Host "`nDone. Exported: $exported, Skipped: $skipped" -ForegroundColor Cyan
+Write-Host "Output directory: $OutputPath" -ForegroundColor Cyan

--- a/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
+++ b/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
@@ -1,13 +1,17 @@
 # ============================================================
 # List and export all survey attachments
 #
-# Usage (all attachments):
+# Parameters:
+#   -ConnectionString (required)  connectionStrings.default from your Checkbox appsettings.json
+#   -OutputPath                   output directory (default: .\CheckboxAttachments)
+#   -SurveyID                     filter to a specific survey by ResponseTemplateID
+#   -IncludeSoftDeleted           also include attachments marked as soft-deleted
+#
+# Usage:
 #   .\list-and-export-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword"
-#
-# Usage (single survey):
-#   .\list-and-export-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012
-#
-# The ConnectionString is the same value as connectionStrings.default in your Checkbox appsettings.json.
+#   .\list-and-export-attachments.ps1 -ConnectionString "..." -SurveyID 1012
+#   .\list-and-export-attachments.ps1 -ConnectionString "..." -SurveyID 1012 -IncludeSoftDeleted
+#   .\list-and-export-attachments.ps1 -ConnectionString "..." -OutputPath "C:\Exports\Attachments"
 # ============================================================
 
 param(

--- a/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
+++ b/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
@@ -7,7 +7,7 @@
 # Usage (single survey):
 #   .\list-and-export-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012
 #
-# The ConnectionString is the same value as DefaultConnection in your Checkbox appsettings.json.
+# The ConnectionString is the same value as connectionStrings.default in your Checkbox appsettings.json.
 # ============================================================
 
 param(
@@ -122,27 +122,31 @@ foreach ($att in $attachments) {
     $fileQuery = "SELECT FileData FROM ckbx_FileUpload WHERE FileID = $($att.FileID) AND FileData IS NOT NULL"
     $conn = New-Object System.Data.SqlClient.SqlConnection($connString)
     $conn.Open()
-    $cmd = $conn.CreateCommand()
-    $cmd.CommandText = $fileQuery
-    $reader = $cmd.ExecuteReader([System.Data.CommandBehavior]::SequentialAccess)
+    try {
+        $cmd = $conn.CreateCommand()
+        $cmd.CommandText = $fileQuery
+        $reader = $cmd.ExecuteReader([System.Data.CommandBehavior]::SequentialAccess)
 
-    if ($reader.Read() -and -not $reader.IsDBNull(0)) {
-        $size = $reader.GetBytes(0, 0, $null, 0, 0)
-        $bytes = [byte[]]::new($size)
-        $reader.GetBytes(0, 0, $bytes, 0, $size)
+        if ($reader.Read() -and -not $reader.IsDBNull(0)) {
+            $size = $reader.GetBytes(0, 0, $null, 0, 0)
+            $bytes = [byte[]]::new($size)
+            $reader.GetBytes(0, 0, $bytes, 0, $size)
 
-        $filePath = Join-Path $folder $att.FileName
-        [System.IO.File]::WriteAllBytes($filePath, $bytes)
-        Write-Host "  OK   FileID $($att.FileID) -> $filePath" -ForegroundColor Green
-        $exported++
+            $filePath = Join-Path $folder $att.FileName
+            [System.IO.File]::WriteAllBytes($filePath, $bytes)
+            Write-Host "  OK   FileID $($att.FileID) -> $filePath" -ForegroundColor Green
+            $exported++
+        }
+        else {
+            Write-Host "  SKIP FileID $($att.FileID) '$($att.FileName)' - no binary data in FileData column" -ForegroundColor Yellow
+            $skipped++
+        }
+
+        $reader.Close()
     }
-    else {
-        Write-Host "  SKIP FileID $($att.FileID) '$($att.FileName)' - no binary data in FileData column" -ForegroundColor Yellow
-        $skipped++
+    finally {
+        $conn.Close()
     }
-
-    $reader.Close()
-    $conn.Close()
 }
 
 Write-Host "`nDone. Exported: $exported, Skipped: $skipped" -ForegroundColor Cyan

--- a/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
+++ b/Surveys/list-and-export-attachments/list-and-export-attachments.ps1
@@ -22,14 +22,12 @@ param(
     [switch]$IncludeSoftDeleted
 )
 
-# Build query — when filtering by survey, use INNER JOINs up the response chain
+# Build query
 if ($SurveyID -gt 0) {
     $surveyFilter = "AND r.ResponseTemplateID = $SurveyID"
-    $responseJoin = "INNER JOIN"
     Write-Host "Filtering to SurveyID: $SurveyID" -ForegroundColor Cyan
 } else {
     $surveyFilter = ""
-    $responseJoin = "LEFT JOIN"
 }
 
 $query = @"
@@ -57,13 +55,12 @@ SELECT
     CASE
         WHEN fuf.FileID IS NOT NULL THEN 'File Upload'
         WHEN sf.FileID IS NOT NULL THEN 'Signature'
-        ELSE 'Orphaned'
     END AS AttachmentType
 FROM ckbx_FileUpload fu
 LEFT JOIN ckbx_ItemData_FileUpload_Files fuf ON fu.FileID = fuf.FileID
 LEFT JOIN ckbx_ItemData_Signature_Files sf ON fu.FileID = sf.FileID
-$responseJoin ckbx_ResponseAnswers ra ON COALESCE(fuf.AnswerID, sf.AnswerID) = ra.AnswerID
-$responseJoin ckbx_Response r ON ra.ResponseID = r.ResponseID
+INNER JOIN ckbx_ResponseAnswers ra ON COALESCE(fuf.AnswerID, sf.AnswerID) = ra.AnswerID
+INNER JOIN ckbx_Response r ON ra.ResponseID = r.ResponseID
 LEFT JOIN ckbx_ResponseTemplate rt ON r.ResponseTemplateID = rt.ResponseTemplateID
 LEFT JOIN ckbx_Item i ON ra.ItemID = i.ItemID
 WHERE (fu.Deleted = 0$(if ($IncludeSoftDeleted) { " OR fu.Deleted = 1" })) $surveyFilter
@@ -131,8 +128,8 @@ foreach ($att in $attachments) {
     }
 
     # Build folder path: files/<SurveyName>/Response-<ResponseID>/
-    $surveyFolder = if ($att.SurveyName -and $att.SurveyName -isnot [DBNull]) { $att.SurveyName -replace '[\\/:*?"<>|]', '_' } else { "_Orphaned" }
-    $responseFolder = if ($att.ResponseID -and $att.ResponseID -isnot [DBNull]) { "Response-$($att.ResponseID)" } else { "_NoResponse" }
+    $surveyFolder = "$($att.SurveyName)" -replace '[\\/:*?"<>|]', '_'
+    $responseFolder = "Response-$($att.ResponseID)"
     $folder = Join-Path $filesDir (Join-Path $surveyFolder $responseFolder)
     New-Item -ItemType Directory -Path $folder -Force | Out-Null
 

--- a/Surveys/list-and-export-attachments/readme.md
+++ b/Surveys/list-and-export-attachments/readme.md
@@ -1,0 +1,51 @@
+# list-and-export-attachments
+
+This script queries the Checkbox database for all survey attachments (file uploads and signatures), prints a summary, exports a CSV report, and dumps all database-stored files to disk.
+
+This script can only be used for on-premises installations.
+
+## Requirements
+
+- PowerShell 5.1+
+- `SqlServer` PowerShell module (`Install-Module SqlServer` if not already installed)
+
+## Usage
+
+Parameters:
+
+- `[string]$ConnectionString` (required) — the `DefaultConnection` value from your Checkbox `appsettings.json`
+- `[string]$OutputPath` — output directory (default: `.\CheckboxAttachments`)
+- `[int]$SurveyID` — filter to a specific survey by its ResponseTemplateID (default: all surveys)
+
+### List and export all attachments
+
+```ps1
+.\list-and-export-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword"
+```
+
+### List and export attachments for a specific survey
+
+```ps1
+.\list-and-export-attachments.ps1 -ConnectionString "Server=localhost;Database=CheckboxSurveys;User Id=CheckboxUser;Password=YourPassword" -SurveyID 1012
+```
+
+## Output
+
+The script creates the following structure in the output directory:
+
+```
+CheckboxAttachments/
+├── attachments-report.csv
+└── files/
+    └── <SurveyName>/
+        └── Response-<ResponseID>/
+            └── <FileName>
+```
+
+- **attachments-report.csv** — full listing of all attachments with metadata (FileID, survey name, response ID, storage type, etc.)
+- **files/** — exported binary files organized by survey name and response
+
+## Notes
+
+- Files stored in Amazon S3 (`StorageType=1`) are included in the CSV report but cannot be exported from the database — they are skipped with a warning during file export.
+- The `ConnectionString` is automatically normalized to handle common keyword variants (e.g., `Initial Catalog` vs `Database`, `Trust Server Certificate` vs `TrustServerCertificate`).

--- a/Surveys/list-and-export-attachments/readme.md
+++ b/Surveys/list-and-export-attachments/readme.md
@@ -16,6 +16,7 @@ Parameters:
 - `[string]$ConnectionString` (required) — the `connectionStrings.default` value from your Checkbox `appsettings.json`
 - `[string]$OutputPath` — output directory (default: `.\CheckboxAttachments`)
 - `[int]$SurveyID` — filter to a specific survey by its ResponseTemplateID (default: all surveys)
+- `[switch]$IncludeSoftDeleted` — also include attachments that have been soft-deleted
 
 ### List and export all attachments
 

--- a/Surveys/list-and-export-attachments/readme.md
+++ b/Surveys/list-and-export-attachments/readme.md
@@ -13,7 +13,7 @@ This script can only be used for on-premises installations.
 
 Parameters:
 
-- `[string]$ConnectionString` (required) — the `DefaultConnection` value from your Checkbox `appsettings.json`
+- `[string]$ConnectionString` (required) — the `connectionStrings.default` value from your Checkbox `appsettings.json`
 - `[string]$OutputPath` — output directory (default: `.\CheckboxAttachments`)
 - `[int]$SurveyID` — filter to a specific survey by its ResponseTemplateID (default: all surveys)
 

--- a/Surveys/list-and-export-attachments/readme.md
+++ b/Surveys/list-and-export-attachments/readme.md
@@ -13,7 +13,7 @@ This script can only be used for on-premises installations.
 
 Parameters:
 
-- `[string]$ConnectionString` (required) — the `connectionStrings.default` value from your Checkbox `appsettings.json`
+- `[string]$ConnectionString` (required) — your Checkbox database connection string (see [Finding your connection string](#finding-your-connection-string))
 - `[string]$OutputPath` — output directory (default: `.\CheckboxAttachments`)
 - `[int]$SurveyID` — filter to a specific survey by its ResponseTemplateID (default: all surveys)
 - `[switch]$IncludeSoftDeleted` — also include attachments that have been soft-deleted
@@ -45,6 +45,11 @@ CheckboxAttachments/
 
 - **attachments-report.csv** — full listing of all attachments with metadata (FileID, survey name, response ID, storage type, etc.)
 - **files/** — exported binary files organized by survey name and response
+
+## Finding your connection string
+
+- **Checkbox 8**: `connectionStrings.default` in `appsettings.json` (in the API Core application directory)
+- **Checkbox 7**: `DefaultConnection` in `Web.config` (in the API application directory, under `<connectionStrings>`)
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- **`Surveys/list-and-export-attachments`**: PowerShell script that queries all survey attachments from the Checkbox database, prints a summary, exports a CSV report, and dumps all DB-stored files to disk in a structured folder layout. Supports filtering to a single survey via `-SurveyID`.
- **`Deletion/delete-survey-attachments`**: PowerShell script that permanently deletes all file attachments for a specific survey. Includes `-DryRun` mode, interactive confirmation, transaction safety, and S3 file warnings.

Both scripts accept a `-ConnectionString` parameter (same value as `DefaultConnection` in Checkbox `appsettings.json`) and handle common ADO.NET keyword variants automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)